### PR TITLE
Add static extensions support for convenient 'using static' directive usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Exceptions/issues/25
-Your prepared branch: issue-25-c5f6994d
-Your prepared working directory: /tmp/gh-issue-solver-1757831306053
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Exceptions/issues/25
+Your prepared branch: issue-25-c5f6994d
+Your prepared working directory: /tmp/gh-issue-solver-1757831306053
+
+Proceed.

--- a/csharp/Platform.Exceptions.Tests/StaticExtensionsTests.cs
+++ b/csharp/Platform.Exceptions.Tests/StaticExtensionsTests.cs
@@ -1,0 +1,74 @@
+using System;
+using Xunit;
+using static Platform.Exceptions.Static.EnsureStatic;
+using static Platform.Exceptions.Static.ThrowStatic;
+
+namespace Platform.Exceptions.Tests
+{
+    public static class StaticExtensionsTests
+    {
+        [Fact]
+        public static void StaticArgumentNotNullTest()
+        {
+            // Test static extension usage with using static directive
+            Assert.Throws<ArgumentNullException>(() => ArgumentNotNull<object>(null, "object"));
+        }
+
+        [Fact]
+        public static void StaticNotSupportedExceptionTest()
+        {
+            // Test static extension usage with using static directive
+            Assert.Throws<NotSupportedException>(() => NotSupportedException());
+        }
+
+        [Fact]
+        public static void StaticNotImplementedExceptionTest()
+        {
+            // Test static extension usage with using static directive
+            Assert.Throws<NotImplementedException>(() => NotImplementedException());
+        }
+
+        [Fact]
+        public static void StaticArgumentMeetsCriteriaTest()
+        {
+            // Test static extension usage with using static directive
+            Assert.Throws<ArgumentException>(() => ArgumentMeetsCriteria(5, x => x > 10, "number", "Number must be greater than 10"));
+        }
+
+        [Fact]
+        public static void StaticNotSupportedExceptionWithMessageTest()
+        {
+            // Test static extension usage with custom message
+            var exception = Assert.Throws<NotSupportedException>(() => NotSupportedException("Custom message"));
+            Assert.Equal("Custom message", exception.Message);
+        }
+
+        [Fact]
+        public static void StaticArgumentNullExceptionTest()
+        {
+            // Test static extension usage for ArgumentNullException
+            Assert.Throws<ArgumentNullException>(() => ArgumentNullException("testParam"));
+        }
+
+        [Fact]
+        public static void StaticArgumentExceptionTest()
+        {
+            // Test static extension usage for ArgumentException
+            Assert.Throws<ArgumentException>(() => ArgumentException("Invalid argument", "testParam"));
+        }
+
+        [Fact]
+        public static void StaticNotSupportedExceptionAndReturnTest()
+        {
+            // Test static extension usage that returns a value
+            Assert.Throws<NotSupportedException>(() => NotSupportedExceptionAndReturn<int>());
+        }
+
+        [Fact]
+        public static void StaticNotImplementedExceptionAndReturnTest()
+        {
+            // Test static extension usage that returns a value
+            Assert.Throws<NotImplementedException>(() => NotImplementedExceptionAndReturn<string>());
+        }
+    }
+}

--- a/csharp/Platform.Exceptions/Static/EnsureStatic.cs
+++ b/csharp/Platform.Exceptions/Static/EnsureStatic.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Platform.Exceptions.Static
+{
+    /// <summary>
+    /// <para>Provides static methods for ensuring contract compliance that can be used with 'using static' directive.</para>
+    /// <para>Предоставляет статические методы для гарантирования соответствия контракту, которые можно использовать с директивой 'using static'.</para>
+    /// </summary>
+    public static class EnsureStatic
+    {
+        /// <summary>
+        /// <para>Ensures that argument is not null.</para>
+        /// <para>Гарантирует, что аргумент не нулевой.</para>
+        /// </summary>
+        /// <typeparam name="TArgument"><para>Type of argument.</para><para>Тип аргумента.</para></typeparam>
+        /// <param name="argument"><para>The argument.</para><para>Аргумент.</para></param>
+        /// <param name="argumentName"><para>The argument's name.</para><para>Имя аргумента.</para></param>
+        /// <param name="message"><para>The message of the thrown exception.</para><para>Сообщение выбрасываемого исключения.</para></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ArgumentNotNull<TArgument>(TArgument argument, string argumentName, string message)
+            where TArgument : class
+            => Ensure.Always.ArgumentNotNull(argument, argumentName, message);
+
+        /// <summary>
+        /// <para>Ensures that argument is not null.</para>
+        /// <para>Гарантирует, что аргумент не нулевой.</para>
+        /// </summary>
+        /// <typeparam name="TArgument"><para>Type of argument.</para><para>Тип аргумента.</para></typeparam>
+        /// <param name="argument"><para>The argument.</para><para>Аргумент.</para></param>
+        /// <param name="argumentName"><para>The argument's name.</para><para>Имя аргумента.</para></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ArgumentNotNull<TArgument>(TArgument argument, string argumentName) where TArgument : class
+            => Ensure.Always.ArgumentNotNull(argument, argumentName);
+
+        /// <summary>
+        /// <para>Ensures that argument is not null.</para>
+        /// <para>Гарантирует, что аргумент не нулевой.</para>
+        /// </summary>
+        /// <typeparam name="TArgument"><para>Type of argument.</para><para>Тип аргумента.</para></typeparam>
+        /// <param name="argument"><para>The argument.</para><para>Аргумент.</para></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ArgumentNotNull<TArgument>(TArgument argument) where TArgument : class
+            => Ensure.Always.ArgumentNotNull(argument);
+
+        /// <summary>
+        /// <para>Ensures that the argument meets the criteria.</para>
+        /// <para>Гарантирует, что аргумент соответствует критерию.</para>
+        /// </summary>
+        /// <typeparam name="TArgument"><para>Type of argument.</para><para>Тип аргумента.</para></typeparam>
+        /// <param name="argument"><para>The argument.</para><para>Аргумент.</para></param>
+        /// <param name="predicate"><para>A predicate that determines whether the argument meets a criterion.</para><para>Предикат определяющий, соответствует ли аргумент критерию.</para></param>
+        /// <param name="argumentName"><para>The argument's name.</para><para>Имя аргумента.</para></param>
+        /// <param name="message"><para>The message of the thrown exception.</para><para>Сообщение выбрасываемого исключения.</para></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ArgumentMeetsCriteria<TArgument>(TArgument argument, Predicate<TArgument> predicate, string argumentName, string message)
+            => Ensure.Always.ArgumentMeetsCriteria(argument, predicate, argumentName, message);
+
+        /// <summary>
+        /// <para>Ensures that the argument meets the criteria.</para>
+        /// <para>Гарантирует, что аргумент соответствует критерию.</para>
+        /// </summary>
+        /// <typeparam name="TArgument"><para>Type of argument.</para><para>Тип аргумента.</para></typeparam>
+        /// <param name="argument"><para>The argument.</para><para>Аргумент.</para></param>
+        /// <param name="predicate"><para>A predicate that determines whether the argument meets a criterion.</para><para>Предикат определяющий, соответствует ли аргумент критерию.</para></param>
+        /// <param name="argumentName"><para>The argument's name.</para><para>Имя аргумента.</para></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ArgumentMeetsCriteria<TArgument>(TArgument argument, Predicate<TArgument> predicate, string argumentName)
+            => Ensure.Always.ArgumentMeetsCriteria(argument, predicate, argumentName);
+
+        /// <summary>
+        /// <para>Ensures that the argument meets the criteria.</para>
+        /// <para>Гарантирует, что аргумент соответствует критерию.</para>
+        /// </summary>
+        /// <typeparam name="TArgument"><para>Type of argument.</para><para>Тип аргумента.</para></typeparam>
+        /// <param name="argument"><para>The argument.</para><para>Аргумент.</para></param>
+        /// <param name="predicate"><para>A predicate that determines whether the argument meets a criterion.</para><para>Предикат определяющий, соответствует ли аргумент критерию.</para></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ArgumentMeetsCriteria<TArgument>(TArgument argument, Predicate<TArgument> predicate)
+            => Ensure.Always.ArgumentMeetsCriteria(argument, predicate);
+    }
+}

--- a/csharp/Platform.Exceptions/Static/ThrowStatic.cs
+++ b/csharp/Platform.Exceptions/Static/ThrowStatic.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Platform.Exceptions.Static
+{
+    /// <summary>
+    /// <para>Provides static methods for throwing exceptions that can be used with 'using static' directive.</para>
+    /// <para>Предоставляет статические методы для выбрасывания исключений, которые можно использовать с директивой 'using static'.</para>
+    /// </summary>
+    public static class ThrowStatic
+    {
+        /// <summary>
+        /// <para>Throws a new <see cref="System.NotSupportedException"/>.</para>
+        /// <para>Выбрасывает новое <see cref="System.NotSupportedException"/>.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void NotSupportedException() => Throw.A.NotSupportedException();
+
+        /// <summary>
+        /// <para>Throws a new <see cref="System.NotSupportedException"/> with the specified message.</para>
+        /// <para>Выбрасывает новое <see cref="System.NotSupportedException"/> с указанным сообщением.</para>
+        /// </summary>
+        /// <param name="message"><para>The message of the thrown exception.</para><para>Сообщение выбрасываемого исключения.</para></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void NotSupportedException(string message) => throw new NotSupportedException(message);
+
+        /// <summary>
+        /// <para>Throws a new <see cref="System.NotSupportedException"/>, while returning a value of <typeparamref name="TReturn"/> type.</para>
+        /// <para>Выбрасывает новое <see cref="System.NotSupportedException"/>, вовращая при этом значение типа <typeparamref name="TReturn"/>.</para>
+        /// </summary>
+        /// <typeparam name="TReturn"><para>The type of returned value.</para><para>Тип возвращаемого значения.</para></typeparam>
+        /// <returns><para>A value of <typeparamref name="TReturn"/> type.</para><para>Значение типа <typeparamref name="TReturn"/>.</para></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TReturn NotSupportedExceptionAndReturn<TReturn>() => Throw.A.NotSupportedExceptionAndReturn<TReturn>();
+
+        /// <summary>
+        /// <para>Throws a new <see cref="System.NotSupportedException"/> with the specified message, while returning a value of <typeparamref name="TReturn"/> type.</para>
+        /// <para>Выбрасывает новое <see cref="System.NotSupportedException"/> с указанным сообщением, вовращая при этом значение типа <typeparamref name="TReturn"/>.</para>
+        /// </summary>
+        /// <typeparam name="TReturn"><para>The type of returned value.</para><para>Тип возвращаемого значения.</para></typeparam>
+        /// <param name="message"><para>The message of the thrown exception.</para><para>Сообщение выбрасываемого исключения.</para></param>
+        /// <returns><para>A value of <typeparamref name="TReturn"/> type.</para><para>Значение типа <typeparamref name="TReturn"/>.</para></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TReturn NotSupportedExceptionAndReturn<TReturn>(string message) => throw new NotSupportedException(message);
+
+        /// <summary>
+        /// <para>Throws a new <see cref="System.NotImplementedException"/>.</para>
+        /// <para>Выбрасывает новое <see cref="System.NotImplementedException"/>.</para>
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void NotImplementedException() => Throw.A.NotImplementedException();
+
+        /// <summary>
+        /// <para>Throws a new <see cref="System.NotImplementedException"/> with the specified message.</para>
+        /// <para>Выбрасывает новое <see cref="System.NotImplementedException"/> с указанным сообщением.</para>
+        /// </summary>
+        /// <param name="message"><para>The message of the thrown exception.</para><para>Сообщение выбрасываемого исключения.</para></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void NotImplementedException(string message) => throw new NotImplementedException(message);
+
+        /// <summary>
+        /// <para>Throws a new <see cref="System.NotImplementedException"/>, while returning a value of <typeparamref name="TReturn"/> type.</para>
+        /// <para>Выбрасывает новое <see cref="System.NotImplementedException"/>, вовращая при этом значение типа <typeparamref name="TReturn"/>.</para>
+        /// </summary>
+        /// <typeparam name="TReturn"><para>The type of returned value.</para><para>Тип возвращаемого значения.</para></typeparam>
+        /// <returns><para>A value of <typeparamref name="TReturn"/> type.</para><para>Значение типа <typeparamref name="TReturn"/>.</para></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TReturn NotImplementedExceptionAndReturn<TReturn>() => Throw.A.NotImplementedExceptionAndReturn<TReturn>();
+
+        /// <summary>
+        /// <para>Throws a new <see cref="System.NotImplementedException"/> with the specified message, while returning a value of <typeparamref name="TReturn"/> type.</para>
+        /// <para>Выбрасывает новое <see cref="System.NotImplementedException"/> с указанным сообщением, вовращая при этом значение типа <typeparamref name="TReturn"/>.</para>
+        /// </summary>
+        /// <typeparam name="TReturn"><para>The type of returned value.</para><para>Тип возвращаемого значения.</para></typeparam>
+        /// <param name="message"><para>The message of the thrown exception.</para><para>Сообщение выбрасываемого исключения.</para></param>
+        /// <returns><para>A value of <typeparamref name="TReturn"/> type.</para><para>Значение типа <typeparamref name="TReturn"/>.</para></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TReturn NotImplementedExceptionAndReturn<TReturn>(string message) => throw new NotImplementedException(message);
+
+        /// <summary>
+        /// <para>Throws a new <see cref="System.ArgumentNullException"/>.</para>
+        /// <para>Выбрасывает новое <see cref="System.ArgumentNullException"/>.</para>
+        /// </summary>
+        /// <param name="argumentName"><para>The argument's name.</para><para>Имя аргумента.</para></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ArgumentNullException(string argumentName) => throw new ArgumentNullException(argumentName);
+
+        /// <summary>
+        /// <para>Throws a new <see cref="System.ArgumentNullException"/>.</para>
+        /// <para>Выбрасывает новое <see cref="System.ArgumentNullException"/>.</para>
+        /// </summary>
+        /// <param name="argumentName"><para>The argument's name.</para><para>Имя аргумента.</para></param>
+        /// <param name="message"><para>The message of the thrown exception.</para><para>Сообщение выбрасываемого исключения.</para></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ArgumentNullException(string argumentName, string message) => throw new ArgumentNullException(argumentName, message);
+
+        /// <summary>
+        /// <para>Throws a new <see cref="System.ArgumentException"/>.</para>
+        /// <para>Выбрасывает новое <see cref="System.ArgumentException"/>.</para>
+        /// </summary>
+        /// <param name="message"><para>The message of the thrown exception.</para><para>Сообщение выбрасываемого исключения.</para></param>
+        /// <param name="argumentName"><para>The argument's name.</para><para>Имя аргумента.</para></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ArgumentException(string message, string argumentName) => throw new ArgumentException(message, argumentName);
+    }
+}

--- a/examples/StaticExtensionsUsage.cs
+++ b/examples/StaticExtensionsUsage.cs
@@ -1,0 +1,55 @@
+using System;
+using Platform.Exceptions;
+// Using static directive for convenient access
+using static Platform.Exceptions.Static.EnsureStatic;
+using static Platform.Exceptions.Static.ThrowStatic;
+
+namespace Platform.Exceptions.Examples
+{
+    public class StaticExtensionsUsage
+    {
+        // Example showing traditional usage vs static extensions usage
+        public void TraditionalUsage()
+        {
+            string parameter = null;
+            
+            // Traditional way - using extension methods on root instances
+            Ensure.Always.ArgumentNotNull(parameter, nameof(parameter));
+            
+            // Throw exceptions the traditional way
+            Throw.A.NotSupportedException();
+        }
+        
+        public void StaticExtensionsUsage()
+        {
+            string parameter = null;
+            
+            // New way - using static imports for cleaner syntax
+            ArgumentNotNull(parameter, nameof(parameter));
+            
+            // Throw exceptions with static methods
+            NotSupportedException();
+        }
+        
+        public void AdvancedStaticUsage()
+        {
+            int value = 5;
+            
+            // Ensure argument meets criteria using static extension
+            ArgumentMeetsCriteria(value, x => x > 0, nameof(value), "Value must be positive");
+            
+            // Throw exceptions with custom messages
+            NotSupportedException("This feature is not yet implemented");
+            NotImplementedException("This method needs to be implemented");
+            
+            // Throw ArgumentNullException directly
+            ArgumentNullException(nameof(value), "Parameter cannot be null");
+        }
+        
+        public T ExampleMethodWithReturn<T>()
+        {
+            // Return type can be inferred while throwing exception
+            return NotSupportedExceptionAndReturn<T>();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Added `Platform.Exceptions.Static.EnsureStatic` with static methods for argument validation 
- Added `Platform.Exceptions.Static.ThrowStatic` with static methods for exception throwing
- Created comprehensive tests demonstrating static usage patterns
- Added example code showing traditional vs static extension usage patterns

## Problem Solved

Issue #25 requested "Static extensions support in the programming language". This implementation allows developers to use C#'s `using static` directive for more convenient and cleaner exception handling syntax.

## Usage Comparison

**Before (traditional extension methods):**
```csharp
using Platform.Exceptions;

// Traditional usage
Ensure.Always.ArgumentNotNull(parameter, nameof(parameter));
Throw.A.NotSupportedException();
```

**After (with static extensions):**
```csharp  
using static Platform.Exceptions.Static.EnsureStatic;
using static Platform.Exceptions.Static.ThrowStatic;

// Cleaner static usage
ArgumentNotNull(parameter, nameof(parameter));
NotSupportedException();
```

## Features Added

### EnsureStatic class provides:
- `ArgumentNotNull<T>()` - validates arguments are not null
- `ArgumentMeetsCriteria<T>()` - validates arguments meet custom criteria

### ThrowStatic class provides:
- `NotSupportedException()` - throws NotSupportedException
- `NotImplementedException()` - throws NotImplementedException  
- `ArgumentNullException()` - throws ArgumentNullException
- `ArgumentException()` - throws ArgumentException
- Return variants for use in expression contexts

## Test plan

- [x] All existing tests continue to pass
- [x] New comprehensive test suite for static methods
- [x] Build succeeds without errors
- [x] Examples demonstrate usage patterns
- [x] Maintains backward compatibility with existing API

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #25